### PR TITLE
ShouldThrowAsync() replacement is incorrect

### DIFF
--- a/migrate_fluentassertions_shouldly.ps1
+++ b/migrate_fluentassertions_shouldly.ps1
@@ -107,9 +107,11 @@ function Replace-WithMessage {
         [string]$content
     )
     $patterns = @(
-        @{ Pattern = 'await\s+(\w+)\.ShouldThrowAsync<([^>]+)>\(\)\s*\.\s*WithMessage\("([^"]+)"\)' ; Replacement = 'await $1.ShouldThrowAsync<$2>("$3")' },
-        @{ Pattern = '(\w+)\.ShouldThrow<([^>]+)>\(\)\s*\.\s*WithMessage\("([^"]+)"\)' ; Replacement = '$1.ShouldThrow<$2>().Message.ShouldBe("$3")' },
-        @{ Pattern = '(\w+)\.ShouldThrow<([^>]+)>\(\)\s*\.\s*WithMessage\(\$"([^"]+)"\)' ; Replacement = '$1.ShouldThrow<$2>().Message.ShouldBe($"$3")' }
+        @{ Pattern = 'await\s+(\w+)\.ShouldThrowAsync<([^>]+)>\(\)\s*\.\s*WithMessage\("([^"]+)"\)' ; Replacement = 'var ex = await $1.ShouldThrowAsync<$2>(); ex.Message.ShouldBe("$3");' },
+        @{ Pattern = '(\w+)\.ShouldThrow<([^>]+)>\(\)\s*\.\s*WithMessage\("([^"]+)"\)' ; Replacement = 'var ex = await $1.ShouldThrow<$2>(); ex.Message.ShouldBe("$3");' },
+        @{ Pattern = '(\w+)\.ShouldThrow<([^>]+)>\(\)\s*\.\s*WithMessage\(\$"([^"]+)"\)' ; Replacement = 'var ex = await $1.ShouldThrow<$2>(); ex.Message.ShouldBe("$3");' },
+        @{ Pattern = 'await\s+(\w+)\.ShouldThrowAsync<([^>]+)>\(\)' ; Replacement = 'var ex = await $1.ShouldThrowAsync<$2>();' },
+        @{ Pattern = '(\w+)\.ShouldThrow<([^>]+)>\(\)' ; Replacement = '$1.ShouldThrow<$2>()' },
     )
 
     foreach ($pattern in $patterns) {


### PR DESCRIPTION
Fixes #1

Update the `migrate_fluentassertions_shouldly.ps1` script to correctly handle `ShouldThrowAsync` and `ShouldThrow` replacements.

- Update the `Replace-WithMessage` function to handle `ShouldThrowAsync` correctly by replacing `await action.ShouldThrowAsync<Exception>().WithMessage("Message")` with `var ex = await action.ShouldThrowAsync<Exception>(); ex.Message.ShouldBe("Message");`.
- Update the `Replace-WithMessage` function to handle `ShouldThrow` correctly by replacing `action.ShouldThrow<Exception>().WithMessage("Message")` with `var ex = await action.ShouldThrow<Exception>(); ex.Message.ShouldBe("Message");`.
- Add patterns for `ShouldThrowAsync` and `ShouldThrow` without `WithMessage` to the `Replace-WithMessage` function.

