### PR TITLE
Update to Shouldly 4.3.0

### DIFF
--- a/migrate_fluentassertions_shouldly.ps1
+++ b/migrate_fluentassertions_shouldly.ps1
@@ -208,7 +208,7 @@ if ($centralPackageFile) {
     $originalCentralContent = $centralContent
 
     # Remove FluentAssertions package and add Shouldly package in the same place
-    $centralContent = $centralContent -replace '<PackageVersion Include="FluentAssertions".*?\/>', '<PackageVersion Include="Shouldly" Version="4.2.1" />'
+    $centralContent = $centralContent -replace '<PackageVersion Include="FluentAssertions".*?\/>', '<PackageVersion Include="Shouldly" Version="4.3.0" />'
 
     # Save updated central package file with the original encoding if it has changed
     if ($centralContent -ne $originalCentralContent) {
@@ -244,9 +244,9 @@ else {
         $originalProjectContent = $projectContent
 
         # Remove FluentAssertions package and add Shouldly package in the same place
-        $projectContent = $projectContent -replace '<PackageReference Include="FluentAssertions".*?\/>', '<PackageReference Include="Shouldly" Version="4.2.1" />'
-        $projectContent = $projectContent -replace '<PackageReference Include="FluentAssertions" \/>', '<PackageReference Include="Shouldly" Version="4.2.1" />'
-        $projectContent = $projectContent -replace '<PackageVersion Include="FluentAssertions".*?\/>', '<PackageVersion Include="Shouldly" Version="4.2.1" />'
+        $projectContent = $projectContent -replace '<PackageReference Include="FluentAssertions".*?\/>', '<PackageReference Include="Shouldly" Version="4.3.0" />'
+        $projectContent = $projectContent -replace '<PackageReference Include="FluentAssertions" \/>', '<PackageReference Include="Shouldly" Version="4.3.0" />'
+        $projectContent = $projectContent -replace '<PackageVersion Include="FluentAssertions".*?\/>', '<PackageVersion Include="Shouldly" Version="4.3.0" />'
 
         # Save updated project file with the original encoding if it has changed
         if ($projectContent -ne $originalProjectContent) {


### PR DESCRIPTION
Fixes #6

Update Shouldly version to 4.3.0 in `migrate_fluentassertions_shouldly.ps1`.

* Update the Shouldly version from 4.2.1 to 4.3.0 in the `$centralContent` replacement.
* Update the Shouldly version from 4.2.1 to 4.3.0 in the `$projectContent` replacement.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/galadril/Shouldly.FromFluentAssertions/pull/7?shareId=aceed6f1-ad4c-4ac6-b8b4-cd0892f247b3).