### PR TITLE
Update Should().ContainSingle to ShouldHaveSingleItem

### DIFF
--- a/migrate_fluentassertions_shouldly.ps1
+++ b/migrate_fluentassertions_shouldly.ps1
@@ -83,7 +83,7 @@ $mapping = @(
     @{ Key = 'Should().HaveSameCount(' ; Value = 'Count.ShouldBe(' },
     @{ Key = 'Should().AllBe(' ; Value = 'ShouldAllBe(' },
     @{ Key = 'Should().Contain().Which.' ; Value = 'ShouldContain(item => item.' },
-    @{ Key = 'Should().ContainSingle(' ; Value = 'ShouldContainSingle(' },
+    @{ Key = 'Should().ContainSingle(' ; Value = 'ShouldHaveSingleItem(' },
     
     # Dictionary assertions
     @{ Key = 'Should().ContainKeyAndValue(' ; Value = 'ShouldContainKeyAndValue(' },


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Correct the assertion mapping for Should().ContainSingle to use the ShouldHaveSingleItem equivalent in the migration script.